### PR TITLE
Arregla el script de comprobación

### DIFF
--- a/scripts/spell_check.sh
+++ b/scripts/spell_check.sh
@@ -26,6 +26,7 @@ let "exitValue += $?"
 # Comprobamos ficheros .tex
 for file in "doc/secciones/*.tex"
 do
+    echo $file
     SpellingError $file;
     let "exitValue += $?"
 done

--- a/scripts/spell_check.sh
+++ b/scripts/spell_check.sh
@@ -3,31 +3,31 @@ SpellingError () {
     error=0;
     echo "";
     echo "Analizando si hay fallos en fichero" $1":";
-    n_line=1; 
+    n_line=1;
     while IFS= read -r line
     do
         resultado=$(echo $line | aspell --mode=tex  --lang=en --list | aspell --mode=tex  --lang=es --list --home-dir=. --personal=.github/workflows/personal-dictionary.txt);
         if [[ ! -z "$resultado" ]]
-        then 
-         echo "Spelling error in line $n_line : $resultado" 
+        then
+         echo "Spelling error in line $n_line : $resultado"
          let "error = 1";
         fi
         let "n_line += 1"
     done < $1
-    return $error; 
+    return $error;
 }
 
-export -f SpellingError; 
+export -f SpellingError;
 exitValue=0
 
-# Comprobamos el readme 
-SpellingError Readme.md
+# Comprobamos el readme
+SpellingError README.md
 let "exitValue += $?"
 # Comprobamos ficheros .tex
 for file in $(find ../doc/secciones -name "*.tex")
-do 
-    SpellingError $file; 
+do
+    SpellingError $file;
     let "exitValue += $?"
 done
 
-exit $exitValue; 
+exit $exitValue;

--- a/scripts/spell_check.sh
+++ b/scripts/spell_check.sh
@@ -24,7 +24,7 @@ exitValue=0
 SpellingError README.md
 let "exitValue += $?"
 # Comprobamos ficheros .tex
-for file in $(find ../doc/secciones -name "*.tex")
+for file in "doc/secciones/*.tex"
 do
     SpellingError $file;
     let "exitValue += $?"

--- a/scripts/spell_check.sh
+++ b/scripts/spell_check.sh
@@ -24,7 +24,7 @@ exitValue=0
 SpellingError README.md
 let "exitValue += $?"
 # Comprobamos ficheros .tex
-for file in "doc/secciones/*.tex"
+for file in "doc/secciones/*.tex doc/*.tex"
 do
     SpellingError $file;
     let "exitValue += $?"

--- a/scripts/spell_check.sh
+++ b/scripts/spell_check.sh
@@ -26,7 +26,6 @@ let "exitValue += $?"
 # Comprobamos ficheros .tex
 for file in "doc/secciones/*.tex"
 do
-    echo $file
     SpellingError $file;
     let "exitValue += $?"
 done

--- a/scripts/spell_check.sh
+++ b/scripts/spell_check.sh
@@ -24,7 +24,13 @@ exitValue=0
 SpellingError README.md
 let "exitValue += $?"
 # Comprobamos ficheros .tex
-for file in "doc/secciones/*.tex doc/*.tex"
+for file in "doc/secciones/*.tex"
+do
+    SpellingError $file;
+    let "exitValue += $?"
+done
+
+for file in "doc/*.tex"
 do
     SpellingError $file;
     let "exitValue += $?"


### PR DESCRIPTION
Por favor, mira lo que usa y adáptalo a tu propio caso; lo que hace es ejecutar un bucle sobre una serie de ficheros y directorios.
Sigue dando error, pero ahora es porque tienes que añadir palabras al diccionario privado.